### PR TITLE
feat: セッションID検証機能を追加

### DIFF
--- a/gui/static/app.js
+++ b/gui/static/app.js
@@ -15,6 +15,23 @@ let isLoopEnabled = false;
 let nextInternalId = 1;  // 内部ID生成用カウンター
 
 // ===========================================
+// セッション管理
+// ===========================================
+
+function handleSessionMismatch() {
+    const reload = confirm(
+        'セッションが無効です。\n' +
+        'サーバーが再起動されたか、別のファイルが読み込まれています。\n\n' +
+        'ページを再読み込みしますか？\n' +
+        '（未保存の変更は失われます）'
+    );
+    if (reload) {
+        location.reload();
+    }
+    setStatus('セッション無効');
+}
+
+// ===========================================
 // 初期化
 // ===========================================
 
@@ -240,6 +257,10 @@ async function saveJson() {
         const result = await response.json();
 
         if (!response.ok) {
+            if (result.error_code === 'SESSION_MISMATCH') {
+                handleSessionMismatch();
+                return;
+            }
             throw new Error(result.error || '保存に失敗しました');
         }
 
@@ -288,6 +309,10 @@ async function regenerateAudio(forceExport = false) {
         const result = await response.json();
 
         if (!response.ok) {
+            if (result.error_code === 'SESSION_MISMATCH') {
+                handleSessionMismatch();
+                return;
+            }
             throw new Error(result.error || '書き出しに失敗しました');
         }
 


### PR DESCRIPTION
## Summary

- サーバー再起動時に古いブラウザセッションからの操作でデータ破損が発生するリスクを防ぐため、セッションID検証を導入
- サーバー起動時にUUIDでセッションIDを生成し、書き込み系API（`/api/save`, `/api/regenerate`）で検証
- セッション不一致時はフロントエンドでユーザーに再読み込みを促すダイアログを表示

## 設計

```
サーバー起動時: session_id = uuid生成（1回だけ）
     ↓
ブラウザアクセス: /api/data → session_id含めて返す
     ↓
フロントエンド: currentDataにsession_id保持
     ↓
保存等の操作時: session_idを送信 → サーバー側で検証
```

## 検証対象API

| API | 検証 | 理由 |
|-----|------|------|
| `/api/save` | ✅ | データ書き込み |
| `/api/regenerate` | ✅ | ファイル生成 |
| `/api/data` | ❌ | 読み取り専用 |
| `/api/waveform` | ❌ | 読み取り専用 |
| `/api/audio` | ❌ | 読み取り専用 |

## Test plan

- [x] サーバー起動後、ブラウザで正常に保存できることを確認
- [x] サーバー再起動後、古いタブから保存を試みるとエラーダイアログが表示されることを確認
- [x] 再読み込み後は正常に操作できることを確認

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)