### PR TITLE
fix: 書き出し後のセグメント削除が反映されないバグを修正

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -532,6 +532,11 @@ def regenerate_audio():
         # edit_segments.jsonを削除
         splitter.delete_edit_segments()
 
+        # _initial_dataを更新（次回の差分計算のため）
+        if _initial_data:
+            _initial_data['_transcript_segments'] = result_segments
+            _initial_data['_edit_segments'] = {}
+
         # 結果メッセージを生成
         messages = []
         if exported_files:


### PR DESCRIPTION
## Summary
- 新規作成したセグメントを書き出し後に削除しても、削除フラグが反映されないバグを修正
- `/api/regenerate`処理後に`_initial_data['_transcript_segments']`を更新するように変更

## 原因
書き出し処理後、メモリ上の`_initial_data['_transcript_segments']`が更新されていなかったため、次回の差分計算時に新規作成したセグメントが「元から存在しない」と判断され、削除対象として認識されなかった。

## Test plan
- [x] 新規セグメントを作成して保存・書き出し
- [x] そのセグメントを削除して保存
- [x] 書き出しを実行し、削除が反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)