### PR TITLE
feat: 波形表示のスクロール・ズーム操作を改善

### DIFF
--- a/gui/static/app.js
+++ b/gui/static/app.js
@@ -444,13 +444,23 @@ function initWavesurfer() {
             });
         }
 
-        // ホイールでズーム
+        // ホイール操作: Ctrl/Shiftでズーム、通常スクロールで横移動
         const waveformEditor = document.getElementById('waveform-editor');
         waveformEditor.addEventListener('wheel', (e) => {
-            if (e.ctrlKey) {
+            if (e.ctrlKey || e.shiftKey) {
+                // Ctrl+ホイール または Shift+ホイール: ズーム
                 e.preventDefault();
                 const delta = e.deltaY > 0 ? -10 : 10;
                 adjustZoom(delta);
+            } else {
+                // 通常ホイール: 横スクロール
+                e.preventDefault();
+                // wavesurferのラッパー要素の親（スクロールコンテナ）を取得
+                const wrapper = wavesurfer.getWrapper();
+                const scrollContainer = wrapper.parentElement;
+                if (scrollContainer) {
+                    scrollContainer.scrollLeft += e.deltaY;
+                }
             }
         }, { passive: false });
     });

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -164,7 +164,8 @@
                         <tr><td><kbd>↑</kbd> <kbd>↓</kbd></td><td>0.1秒移動</td></tr>
                         <tr><td><kbd>,</kbd> <kbd>.</kbd></td><td>5秒移動</td></tr>
                         <tr><td><kbd>+</kbd> <kbd>-</kbd></td><td>ズームイン/アウト</td></tr>
-                        <tr><td><kbd>Ctrl</kbd>+<kbd>ホイール</kbd></td><td>ズームイン/アウト</td></tr>
+                        <tr><td><kbd>ホイール</kbd></td><td>波形を横スクロール</td></tr>
+                        <tr><td><kbd>Ctrl/Shift</kbd>+<kbd>ホイール</kbd></td><td>ズームイン/アウト</td></tr>
                         <tr><td><kbd>Delete</kbd></td><td>セグメント削除</td></tr>
                         <tr><td><kbd>></kbd> <kbd><</kbd></td><td>再生速度変更</td></tr>
                         <tr><td><kbd>Ctrl+S</kbd></td><td>保存</td></tr>


### PR DESCRIPTION
## Summary
- 通常ホイールで波形を横スクロール可能に
- Ctrl+ホイール または Shift+ホイールでズーム
- ヘルプモーダルに新しいショートカットを追加

Closes #15

## Test plan
- [x] 波形表示エリアでホイールスクロール → 横移動することを確認
- [x] Ctrl+ホイールでズームイン/アウトすることを確認
- [x] Shift+ホイールでズームイン/アウトすることを確認
- [x] ヘルプモーダル(?)に新しいショートカットが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)