### PR TITLE
fix: .batファイルの改行コードがリリースでLFになる問題を修正

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Default: auto-detect and normalize to LF in repo, native on checkout
+* text=auto
+
+# Windows batch/PowerShell files must keep CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf


### PR DESCRIPTION
## Summary
- `.gitattributes` を追加し、`.bat`/`.cmd`/`.ps1` ファイルのチェックアウト時にCRLFを保証
- CIの `ubuntu-latest` 上でもリリースパッケージ内の `.bat` ファイルが正しい改行コードになる

Closes #26

## Test plan
- [x] リリースビルドで `.bat` ファイルがCRLFになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)